### PR TITLE
add GraphMetrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Awesome Lisp Company is the curated lisp for companies that use Lisp Extensively
 - [GrammaTech](https://www.grammatech.com/)
   - Source code analysis tools for C, C++, Ada. Ithaca, NY. [Hiring software engineers](http://www.grammatech.com/corporate/employment.html) and interns with experience programming in Scheme, compilers, and static analysis.
   - *Active as of January 2018*
+- [GraphMetrix](https://graphmetrix.com/)
+  - automation of document extraction and publishing for construction, property and logistics.
+  - *Active as of September 2020*.
+> "We are using Lisp as the main engine for our RDF -> Sparql -> in-memory rdf db -> conceptual inference system at graphMetrix"
 - [iRobot](http://www.irobot.com/)
   - a company that designs and builds consumer robots for inside and
     outside of the home, including a range of autonomous home vacuum


### PR DESCRIPTION
its co-founder commented on LinkedIn, Common Lisp group how they use
CL.

https://www.reddit.com/r/Common_Lisp/comments/iq7fyj/another_lisp_company_graphmetrix/

    "we are using Lisp as the main engine for our RDF -> Sparql -> in-memory rdf db -> conceptual inference system at graphMetrix"

    "We built on top of the Wilbur library and converted it into quads with graph db sync and multi-core processing safe and many other forms of turbo-charging - it's ridiculously fast."

    "We've now switched over to cl-containers + cl-graph which helps in many ways in terms of inference but also can handle massive scale in parallel."