### PR TITLE
add Mimix, Nebula

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,11 @@ Awesome Lisp Company is the curated lisp for companies that use Lisp Extensively
 ## Virtual or Unsure of Location
 
 - the [PostgreSQL](https://www.postgresql.org) organization uses Common Lisp in at least two products:
-  - [pgloader](http://pgloader.io/) (see [why it was rewritting from Python](https://tapoueh.org/blog/2014/05/why-is-pgloader-so-much-faster/)), and
+  - [pgloader](http://pgloader.io/) (see [why it was rewritten from Python](https://tapoueh.org/blog/2014/05/why-is-pgloader-so-much-faster/)), and
   - [pgcharts](https://github.com/dimitri/pgcharts).
+- [Mimix](https://nebula.mimix.io/), developing Nebula, a suite of new tools for working with facts and documents. 
+  - uses SBCL, Electron, AngularJS.
+  - active as of December, 2020.
 - [Raytheon SigLab](http://www.lispworks.com/success-stories/raytheon-siglab.html)
   - a signal processing analysis pipeline for developing algorithms. A LispWorks success story.
 - [Untyped](https://untyped.com/)


### PR DESCRIPTION
as of this HN discussion: https://news.ycombinator.com/item?id=25442338

«
For anyone who needs a "download and go" way to play with Lisp, Allegro offers a free version. It's one installation. For VS Code, I'd wire-up SBCL as others have said. It's a little touchy to get setup but we produced our product with it so it does work.

The whole issue of "flavors" largely comes down to one concept: Do you like the idea of functions and variables being in the same namespace (that's called a Lisp 1 like Scheme) or different (a Lisp 2 like CL). If you don't care, it doesn't matter which you pick.

If you're going to extend your Lisp app into production, you might want some of the many libraries that are available for CL. These cover just about every known topic and algorithm in comp sci and they're old and proven and just work everywhere, so that can be a benefit as you move to a non-trial app.

If you're going to distribute something written in Lisp (like an executable), then the flavor and implementation you pick will need to work all the way down your distribution path, and that can be challenging to get setup. One proven path is SBCL + Node.js + Electron to wrap your app for all three platforms.
»