### PR TITLE
Remove LambdaWerk

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,6 @@ Awesome Lisp Company is the curated lisp for companies that use Lisp Extensively
   - 3D CAD modeler for “explicit modeling”. Sindelfingen, Germany. 1M+ lines of Lisp, previously part of HP, paper on[ Common Lisp as an Embedded Extension Language](http://www.hpl.hp.com/hpjournal/95oct/oct95a7.pdf). Recent blog post about [CL use](http://www.clausbrod.de/cgi-bin/view.pl/Blog/WebHome#DefinePrivatePublic20071229_Comm)
 - [Cognesys](http://www.cognesys.de/) &#9746;
   - “automatic ascertainment and further processing of verbal and text messages” (Natural Language Processing). Ubach-Palenburg, Germany. Looking for experienced and fresh Lisp programmers
-- [LambdaWerk](https://lambdawerk.com)
-  - a software development and Web engineering company in Berlin, Germany, specialized in data interchange and transformation systems for the U.S. managed healthcare sector. Uses Clojure and Common Lisp.
-
 - [MTU Aero Engines](https://www.mtu.de/)
   - MTU Aero Engines is Germany's leading engine manufacturer and an established global player in the industry. It engages in the development, manufacture, marketing and support of commercial and military aircraft engines in all thrust and power categories and industrial gas turbines. They use [Allegro CL](https://franz.com/success/customer_apps/mechanical_cad/mtu.lhtml).
 - [m-creations](http://www.m-creations.com/)


### PR DESCRIPTION
https://lambdawerk.com/ has an expired HTTPS certificate. The website itself suggests the company is defunct:

> LambdaWerk was a software development and consulting company in Berlin, Germany. We specialized in EDI systems for the US healthcare market.