### PR TITLE
Fix for issue #68 (removes AMARC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Awesome Lisp Company is the curated lisp for companies that use Lisp Extensively
 ### Canada
 
 -  AMARC &#128124;
-   - organization supporting community radio broadcasting. Montreal, Canada. [ob page mentions Scheme, web development, and graphics. Uses a Wiki powered by Gauche
+   - organization supporting community radio broadcasting. Montreal, Canada. Job page mentions Scheme, web development, and graphics. Uses a Wiki powered by Gauche
 -  [Carre Technologies](http://www.carretechnologies.com/)
    - intelligent machines. Montreal, Canada. Main page just lets you send mail, but the site includes a Chicken Scheme extension for Gnu/Octave and a floating point vector and matrix library for Gambit Scheme.
 -  Categorical Design Solutions &#128124;


### PR DESCRIPTION
Removing AMARC because it seems to be dead. The links provided also do not redirect to anything resembling that, so I removed the link as well.
