### PR TITLE
Adds GeneNetwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Awesome Lisp Company is the curated lisp for companies that use Lisp Extensively
 
 ## Virtual or Unsure of Location
 
+- [GeneNetwork](https://github.com/genenetwork/) uses [GNU Guix](https://guix.gnu.org/) and scheme extensively in production.
 - the [PostgreSQL](https://www.postgresql.org) organization uses Common Lisp in at least two products:
   - [pgloader](http://pgloader.io/) (see [why it was rewritting from Python](https://tapoueh.org/blog/2014/05/why-is-pgloader-so-much-faster/)), and
   - [pgcharts](https://github.com/dimitri/pgcharts).


### PR DESCRIPTION
[GeneNetwork](https://github.com/genenetwork/) uses [GNU Guix](https://guix.gnu.org/) and scheme (guile and racket) extensively in production.

## Checklist

- [X ] This company uses Common Lisp or Scheme in production
