### PR TITLE
Remove outdated LinkedIn group link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Awesome Lisp Company is the curated lisp for companies that use Lisp Extensively
 To hear about more companies and job offerings, see:
 
 - [LinkedIn Common Lisp Open-Source](https://www.linkedin.com/groups/8876366/)
-- [LinkedIn Common Lisp](https://www.linkedin.com/groups/830547)
 - social media
 
 For more resources, see:


### PR DESCRIPTION
docs: remove broken LinkedIn group link (fixes #98)
This PR only updates documentation — no company entries affected.

## Checklist
- [x] N/A (no company added or modified)